### PR TITLE
adding public to some vars

### DIFF
--- a/com/newgonzo/midi/file/messages/SetTempoMessage.hx
+++ b/com/newgonzo/midi/file/messages/SetTempoMessage.hx
@@ -2,8 +2,8 @@ package com.newgonzo.midi.file.messages;
 
 class SetTempoMessage extends MetaEventMessage {
 	
-	var microsecondsPerQuarter(default, null):UInt;
-	var tempo(default, null):UInt;
+	public var microsecondsPerQuarter(default, null):UInt;
+	public var tempo(default, null):UInt;
 	
 	public function new (microsecondsPerQuarter:UInt) {
 		super(MetaEventMessageType.SET_TEMPO);


### PR DESCRIPTION
allow setTempo introspection to be able to reconstruct tempo timetable at runtime
